### PR TITLE
Update spotify client location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0.32.94.g8a839395-32
+VERSION=1.0.32.96.g3c8a06e6-37
 DEBNAME=spotify-client_$(VERSION)_amd64.deb
 
 all: repo data.tar.gz com.spotify.Client.json


### PR DESCRIPTION
The Spotify client has been updated and the old version has been removed. (aur.archlinux.org/packages/spotify [1]  is a good source for the most recent Spotify client names).

Apart from this the Spotify flatpak works great. I think this will be my new favourite way to use Spotify on Fedora!

Thank you for your work on flatpak! I know it's far from being done, but it's already amazing!

[1]: Maybe something like the AUR would be great for flatpak build recipes? Especially for things like non-redistributable apps like Spotify that would be ideal.